### PR TITLE
use Environment instead of EnvironmentObject for PersistenceManger

### DIFF
--- a/BetterEveryDay/BetterEveryDay.xcodeproj/project.pbxproj
+++ b/BetterEveryDay/BetterEveryDay.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		2433A0962AAFA54200621188 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2433A0952AAFA54200621188 /* SettingsView.swift */; };
 		246D6C2E2A48990300E5B39B /* TimerLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246D6C2D2A48990300E5B39B /* TimerLabelView.swift */; };
 		246D6C302A4899E100E5B39B /* PhaseLabelModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246D6C2F2A4899E100E5B39B /* PhaseLabelModifier.swift */; };
+		247FC7AF2C84401C00B72733 /* EnvironmentValues+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247FC7AE2C84401C00B72733 /* EnvironmentValues+Ext.swift */; };
 		247FD12B2B72BDE7009CEB88 /* BackgroundElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247FD12A2B72BDE7009CEB88 /* BackgroundElement.swift */; };
 		24912E572B9F5F96001AB4C7 /* WanderingShadowAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24912E562B9F5F96001AB4C7 /* WanderingShadowAnimation.swift */; };
 		24912E592B9F7910001AB4C7 /* ThirdTimeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24912E582B9F7910001AB4C7 /* ThirdTimeState.swift */; };
@@ -77,6 +78,7 @@
 		2433A0952AAFA54200621188 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		246D6C2D2A48990300E5B39B /* TimerLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerLabelView.swift; sourceTree = "<group>"; };
 		246D6C2F2A4899E100E5B39B /* PhaseLabelModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhaseLabelModifier.swift; sourceTree = "<group>"; };
+		247FC7AE2C84401C00B72733 /* EnvironmentValues+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+Ext.swift"; sourceTree = "<group>"; };
 		247FD12A2B72BDE7009CEB88 /* BackgroundElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundElement.swift; sourceTree = "<group>"; };
 		24912E562B9F5F96001AB4C7 /* WanderingShadowAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WanderingShadowAnimation.swift; sourceTree = "<group>"; };
 		24912E582B9F7910001AB4C7 /* ThirdTimeState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdTimeState.swift; sourceTree = "<group>"; };
@@ -231,6 +233,7 @@
 		247FD1272B72B978009CEB88 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				247FC7AE2C84401C00B72733 /* EnvironmentValues+Ext.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -513,6 +516,7 @@
 				2406EB142A70F2E200E3FF6A /* TimeSpendData.swift in Sources */,
 				24E924362A457B8D002CA7F8 /* PrimaryButton.swift in Sources */,
 				24F53FA72C6899DA00C6A666 /* SessionCategory.swift in Sources */,
+				247FC7AF2C84401C00B72733 /* EnvironmentValues+Ext.swift in Sources */,
 				2406EB2D2A7FE72000E3FF6A /* RequestNotificationView.swift in Sources */,
 				24912E5D2BAA2DBE001AB4C7 /* SessionScreen.swift in Sources */,
 				24F3F2962B1A39C8008063B2 /* SessionData.swift in Sources */,

--- a/BetterEveryDay/BetterEveryDay/BetterEveryDayApp.swift
+++ b/BetterEveryDay/BetterEveryDay/BetterEveryDayApp.swift
@@ -20,7 +20,7 @@ struct BetterEveryDayApp: App {
         }
         .modelContainer(persistenceManager.modelContainer)
         .environment(notificationManager)
-        .environmentObject(persistenceManager)
+        .environment(\.persistenceManager, persistenceManager)
     }
 }
 

--- a/BetterEveryDay/BetterEveryDay/Extensions/EnvironmentValues+Ext.swift
+++ b/BetterEveryDay/BetterEveryDay/Extensions/EnvironmentValues+Ext.swift
@@ -1,0 +1,20 @@
+//
+//  EnvironmentValues+Ext.swift
+//  BetterEveryDay
+//
+//  Created by Julian Schenkemeyer on 01.09.24.
+//
+
+import SwiftUI
+
+
+private struct PersistenceManagerKey: EnvironmentKey {
+    static let defaultValue: any PersistenceManagerProtocol = PersistenceManagerMock()
+}
+
+extension EnvironmentValues {
+    var persistenceManager: any PersistenceManagerProtocol {
+        get { self[PersistenceManagerKey.self] }
+        set { self[PersistenceManagerKey.self] = newValue }
+    }
+}

--- a/BetterEveryDay/BetterEveryDay/Extensions/EnvironmentValues+Ext.swift
+++ b/BetterEveryDay/BetterEveryDay/Extensions/EnvironmentValues+Ext.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 
 private struct PersistenceManagerKey: EnvironmentKey {
-    static let defaultValue: any PersistenceManagerProtocol = PersistenceManagerMock()
+    static let defaultValue: (any PersistenceManagerProtocol)? = nil
 }
 
 extension EnvironmentValues {
-    var persistenceManager: any PersistenceManagerProtocol {
+    var persistenceManager: (any PersistenceManagerProtocol)? {
         get { self[PersistenceManagerKey.self] }
         set { self[PersistenceManagerKey.self] = newValue }
     }

--- a/BetterEveryDay/BetterEveryDay/Manager/PersistenceManager.swift
+++ b/BetterEveryDay/BetterEveryDay/Manager/PersistenceManager.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftData
 
 /// Defines the functions needed to persist the session
-protocol PersistenceManagerProtocol: ObservableObject {
+protocol PersistenceManagerProtocol: Observable {
     /// Create a new session entry in the persistence layer
     /// - Parameter sessionController: ``SessionController``  to be persisted
     func insertSession(from sessionController: SessionController)

--- a/BetterEveryDay/BetterEveryDay/Screens/SessionScreen.swift
+++ b/BetterEveryDay/BetterEveryDay/Screens/SessionScreen.swift
@@ -14,7 +14,7 @@ enum Phases: String, Codable {
 struct SessionScreen: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(NotificationManager.self) private var notificationManager
-    @EnvironmentObject var persistenceManager: SwiftDataPersistenceManager
+    @Environment(\.persistenceManager) var persistenceManager
     
     @State private var goneOvertime = false
     
@@ -94,7 +94,7 @@ struct SessionScreen: View {
         }
         
         viewModel.next() { data in
-            persistenceManager.updateSession(with: data)
+            persistenceManager?.updateSession(with: data)
         }
         removeScheduledNotifications()
         if segment.category == .Focus {
@@ -137,5 +137,5 @@ struct SessionScreen: View {
 #Preview {
     SessionScreen(goal: "work on session screen work on session screen", viewModel: Session(segments: [.init(category: .Focus, startedAt: .now)]))
         .environment(NotificationManager(notificationService: NotificationServiceMock()))
-        .environmentObject(PersistenceManagerMock())
+        .environment(\.persistenceManager, PersistenceManagerMock())
 }


### PR DESCRIPTION
Allows using the mock version in previews and using the SwiftData one for the build without crashing 